### PR TITLE
fix: correctly initialize jobs enqueuer's Redis connection

### DIFF
--- a/ENV.md
+++ b/ENV.md
@@ -36,7 +36,8 @@ The following environment variables are only applicable when running in `events_
 
 The following environment variables are only applicable when running in `jobs_worker` mode.
 
-- `REDIS_URL`: The URL of the Redis instance to use for jobs. Must be set when using the `jobs_worker` mode.
+- `REDIS_URL`: The Redis URL to use for the `gocraft_work` backend, e.g. `redis://localhost:6379`. Required.
+- `REDIS_POOL`: The maximum number of active connections to the Redis instance. Default: `5`.
 
 ## gRPC
 

--- a/foundation.go
+++ b/foundation.go
@@ -276,9 +276,14 @@ func (s *Service) addSystemComponents() error {
 	}
 
 	if s.Config.JobsEnqueuer.Enabled {
+		redisAddress, err := ExtractHostAndPort(s.Config.JobsEnqueuer.URL)
+		if err != nil {
+			return fmt.Errorf("failed to extract host and port from redis URL: %w", err)
+		}
+
 		s.Components = append(s.Components, fjobs.NewComponent(
 			fjobs.WithLogger(s.Logger),
-			fjobs.WithURL(s.Config.JobsEnqueuer.URL),
+			fjobs.WithAddress(redisAddress),
 			fjobs.WithPoolSize(s.Config.JobsEnqueuer.Pool),
 		))
 	}

--- a/helpers.go
+++ b/helpers.go
@@ -2,6 +2,7 @@ package foundation
 
 import (
 	"fmt"
+	"net/url"
 	"reflect"
 	"strings"
 )
@@ -22,4 +23,16 @@ func AddSuffix(s string, suffix string) string {
 // Clone clones an object.
 func Clone(obj interface{}) interface{} {
 	return reflect.New(reflect.TypeOf(obj)).Interface()
+}
+
+func ExtractHostAndPort(URL string) (string, error) {
+	parsedURL, err := url.Parse(URL)
+	if err != nil {
+		return "", err
+	}
+
+	host := parsedURL.Hostname()
+	port := parsedURL.Port()
+
+	return fmt.Sprintf("%s:%s", host, port), nil
 }

--- a/jobs/enqueuer.go
+++ b/jobs/enqueuer.go
@@ -20,7 +20,7 @@ const (
 type Component struct {
 	Enqueuer *work.Enqueuer
 
-	url       string
+	address   string
 	namespace string
 	poolSize  int
 	logger    *logrus.Entry
@@ -36,10 +36,10 @@ func WithLogger(logger *logrus.Entry) ComponentOption {
 	}
 }
 
-// WithURL sets the database URL for the JobsEnqueuer component.
-func WithURL(url string) ComponentOption {
+// WithAddress sets the redis address for the JobsEnqueuer component.
+func WithAddress(address string) ComponentOption {
 	return func(c *Component) {
-		c.url = url
+		c.address = address
 	}
 }
 
@@ -82,7 +82,7 @@ func (c *Component) Start() error {
 		MaxIdle:   c.poolSize,
 		Wait:      true,
 		Dial: func() (redis.Conn, error) {
-			return redis.Dial("tcp", c.url)
+			return redis.Dial("tcp", c.address)
 		},
 	})
 

--- a/jobs_worker.go
+++ b/jobs_worker.go
@@ -69,12 +69,17 @@ func (w *JobsWorker) Start(opts *JobsWorkerOptions) {
 }
 
 func (w *JobsWorker) ServiceFunc(ctx context.Context) error {
+	redisAddress, err := ExtractHostAndPort(w.Config.JobsEnqueuer.URL)
+	if err != nil {
+		return fmt.Errorf("failed to extract host and port from redis URL: %w", err)
+	}
+
 	var redisPool = &redis.Pool{
 		MaxActive: w.Options.Concurrency,
 		MaxIdle:   w.Options.Concurrency,
 		Wait:      true,
 		Dial: func() (redis.Conn, error) {
-			return redis.Dial("tcp", w.Config.Redis.URL)
+			return redis.Dial("tcp", redisAddress)
 		},
 	}
 


### PR DESCRIPTION
Redis pool (redigo) requires a network address to connect. Add redis URL parser to extract host and port for jobs worker and jobs enqueuer