### PR TITLE
feat(events_worker): added error modes

### DIFF
--- a/events_worker.go
+++ b/events_worker.go
@@ -26,11 +26,21 @@ type EventHandler interface {
 	Handle(context.Context, *Event, proto.Message) ([]*Event, ferr.FoundationError)
 }
 
+// ErrorModeEnum defines the EventsWorker behavior when errors occur while handle event
+type ErrorModeEnum int
+
+const (
+	ErrorModeEnumSkip ErrorModeEnum = iota // Default: commit message and skip the event
+	ErrorModeEnumStop                      // Stop the worker
+	// ErrorModeEnumRetry                  // Retry the event // TODO: implement retry mode
+)
+
 // EventsWorkerOptions represents the options for starting an events worker
 type EventsWorkerOptions struct {
 	Handlers               map[proto.Message][]EventHandler
 	Topics                 []string
 	ModeName               string
+	ErrorMode              ErrorModeEnum
 	StartComponentsOptions []StartComponentsOption
 }
 
@@ -97,7 +107,7 @@ func (w *EventsWorker) Start(opts *EventsWorkerOptions) {
 
 	wOpts := NewSpinWorkerOptions()
 	wOpts.ModeName = opts.ModeName
-	wOpts.ProcessFunc = w.newProcessEventFunc(opts.Handlers)
+	wOpts.ProcessFunc = w.newProcessEventFunc(opts.Handlers, opts.ErrorMode)
 	wOpts.StartComponentsOptions = append(opts.StartComponentsOptions,
 		WithKafkaConsumer(),
 		WithKafkaConsumerTopics(opts.GetTopics()...),
@@ -122,7 +132,10 @@ func newEventFromKafkaMessage(msg *kafka.Message) *Event {
 	}
 }
 
-func (w *EventsWorker) newProcessEventFunc(handlers map[proto.Message][]EventHandler) func(ctx context.Context) ferr.FoundationError {
+func (w *EventsWorker) newProcessEventFunc(
+	handlers map[proto.Message][]EventHandler,
+	errorMode ErrorModeEnum,
+) func(ctx context.Context) ferr.FoundationError {
 	return func(ctx context.Context) ferr.FoundationError {
 		msg, err := w.GetKafkaConsumer().FetchMessage(ctx)
 		if err != nil {
@@ -180,10 +193,11 @@ func (w *EventsWorker) newProcessEventFunc(handlers map[proto.Message][]EventHan
 			log.Info("Event processed successfully")
 		}
 
-		// For now, we commit the message even if the handler failed to process it.
-		//
-		// TODO: add a configuration option to allow the user to choose whether to commit the message or not.
-		// Or maybe even publish the message to a dead-letter topic?
+		if handleErr != nil && errorMode == ErrorModeEnumStop {
+			w.Logger.WithField("event", event.ProtoName).Fatalf("Cannot process event: %v", handleErr)
+		}
+		// Else: errorMode == Skip
+
 		if commitErr := w.CommitMessage(ctx, msg); commitErr != nil {
 			return commitErr
 		}

--- a/foundation.go
+++ b/foundation.go
@@ -26,6 +26,7 @@ type Service struct {
 	Config     *Config
 	Components []Component
 	ModeName   string
+	cancelFunc context.CancelFunc
 
 	Logger *logrus.Entry
 }
@@ -362,6 +363,8 @@ func (s *Service) Start(opts *StartOptions) {
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
+
+	s.cancelFunc = stop
 
 	// Run the actual service code
 	if err := opts.ServiceFunc(ctx); err != nil {


### PR DESCRIPTION
Events worker:
While handling events from kafka, errors can appears. Error mode decide what to do in this case.

ErrorModeEnumSkip // Default: commit message and skip the event
ErrorModeEnumStop // Stop the worker

Usage example:

```golang

var service = f.InitEventsWorker("events-worker")

func main() {
	eventsWorker := &EventsWorker{}

	opts := f.EventsWorkerOptions{
		ModeName:               "events_worker",
		StartComponentsOptions: []f.StartComponentsOption{},
		ErrorMode:              f.ErrorModeEnumStop, // NEW
		Handlers: map[proto.Message][]f.EventHandler{},
	}

	service.Start(&opts)
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Enhanced error handling in event processing with configurable behaviors.
    - Added a cancel functionality to gracefully stop services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->