### PR TITLE
fix(kafka): set default producing stratefy as hash to distribute messages by partitions based on key

### DIFF
--- a/ENV.md
+++ b/ENV.md
@@ -61,6 +61,8 @@ The following environment variables are only applicable when running in `jobs_wo
   - `ca.crt`: The CA certificate.
   - `server.crt`: The client certificate.
   - `server.key`: The client key.
+- `KAFKA_PRODUCER_BATCH_SIZE`: The maximum number of messages to batch before sending to Kafka. Default: `1`.
+- `KAFKA_PRODUCER_BATCH_TIMEOUT`: The maximum time to wait before sending a batch of messages to Kafka in seconds. Default: `1`.
 
 ## PostgreSQL
 


### PR DESCRIPTION
…ages by keys


## Summary by CodeRabbit
- **Fixes**
  - Set balancer strategy for kafka producer as `Hash` to distribute messages by partitions based on key. The default one value is round-robin, which is not suitable with keys in events.
 
- **New Features**
  - Added environment variables for configuring Kafka producer batch size (`KAFKA_PRODUCER_BATCH_SIZE`) and batch timeout (`KAFKA_PRODUCER_BATCH_TIMEOUT`). Kafka producer now supports configurable batch size and timeout, improving flexibility and performance tuning.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->